### PR TITLE
Add transaction name to Actual Budget's Notes field

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,6 +17,7 @@ const ACTUAL_ACCOUNT = process.env.ACTUAL_ACCOUNT || "";
 const CRON_EXPRESSION = process.env.CRON_EXPRESSION || "";
 const ACTUAL_SYNC_ID = process.env.ACTUAL_SYNC_ID || "";
 const IMPORT_FROM = process.env.IMPORT_FROM || "";
+const ADD_PAYEE_TO_TRANSACTION_NOTES = process.env.ADD_PAYEE_TO_TRANSACTION_NOTES === 'true';
 
 
 function getAppConfigFromEnv() {
@@ -59,7 +60,8 @@ function getAppConfigFromEnv() {
         ACTUAL_SERVER_PASSWORD,
         ACTUAL_SYNC_ID,
         CRON_EXPRESSION,
-        IMPORT_FROM
+        IMPORT_FROM,
+        ADD_PAYEE_TO_TRANSACTION_NOTES
     }
 
     // Assert that all required environment variables are set

--- a/edenredService.js
+++ b/edenredService.js
@@ -65,10 +65,10 @@ async function getTransactions(accountId) {
             payee_name: transaction.transactionName,
             imported_payee: transaction.transactionName,
             imported_id: transactionID,
+            notes: transaction.transactionName,
             cleared: true,
         })
     });
-    
 
     return parsedTransactions
 }

--- a/edenredService.js
+++ b/edenredService.js
@@ -65,7 +65,7 @@ async function getTransactions(accountId) {
             payee_name: transaction.transactionName,
             imported_payee: transaction.transactionName,
             imported_id: transactionID,
-            notes: transaction.transactionName,
+            notes: appConfig.ADD_PAYEE_TO_TRANSACTION_NOTES ? transaction.transactionName : '',
             cleared: true,
         })
     });


### PR DESCRIPTION
I personally find doing this useful with other importers since it allows me to: have custom rules in Actual to normalize payee names but still keep it's old value in the notes field for a deeper knowledge of the transaction.